### PR TITLE
Fix downloads for new releases

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -19,9 +19,9 @@ error_exit() {
 }
 
 get_platform() {
-  local testStr="$(uname | tr '[:upper:]' '[:lower:]')"
-  if [ "$testStr" == "darwin" ]; then
-    echo "osx"
+  local plat="$(uname | tr '[:upper:]' '[:lower:]')"
+  if [ "$plat" == "darwin" ]; then
+    echo "macos"
   else
     echo "linux"
   fi
@@ -29,17 +29,14 @@ get_platform() {
 }
 get_arch(){
   declare arch="$(uname -m)"
-  if [ "$arch" == 'x86_64' ]; then
-    echo '64'
-  elif [ "$arch" == 'i386' ]; then
-    echo '32'
-  elif [ "$arch" == 'i686' ]; then
-    echo '32'
-  elif [ "$arch" == 'arm64' ]; then
-    echo 'arm64'
-  else
-    error_exit 'Sadly, there are no official releases for your architecture'
-  fi
+  case "$arch" in
+    x86_64 | amd64) echo "amd64" ;;
+    x86 | i686 | i386 | 386) echo "i386" ;;
+    aarch64 | arm64) echo "arm64" ;;
+    armv7l) echo "armhf" ;;
+    armv6l) echo "armel" ;;
+    *) error_exit "Unsupported architecture $arch" ;;
+  esac
   return
 }
 
@@ -88,22 +85,23 @@ filter_assets() {
 
   declare platform="$(get_platform)";
   declare arch="$(get_arch)"
+  declare -a filters=("${platform}-${arch}")
   declare -a filteredArr=()
 
-  for i in "${inArr[@]}"; do
-    if [ "$arch" == "32" ]; then
-      declare filteredUrl="$(echo "$i" | sed -n -E "/.*$platform.*(86|32)/p" | sed -n -E '/.*86_64.*/!p')"
-      declare canPass="$(echo "$filteredUrl" | sed -n -E 's/.*[[:alpha:]].*/true/p')"
-      if [ "$canPass" == "true" ]; then
-        filteredArr+=("$filteredUrl")
+  # Handle older platform-arch naming scheme
+  case "${platform}-${arch}" in
+    linux-amd64) filters+=(linux64 linux-x86_64) ;;
+    linux-i386) filters+=(linux32 linux-x86) ;;
+    macos-amd64) filters+=(osx-amd64 osx-x86_64) ;;
+    macos-i386) filters+=(osx-x86) ;;
+  esac
+
+  for input in "${inArr[@]}"; do
+    for filter in "${filters[@]}"; do
+      if [[ "$input" == *"$filter"* ]]; then
+        filteredArr+=("$input")
       fi
-    else
-      declare filteredUrl="$(echo "$i" | sed -n -E "/$platform.*(64)/p")"
-      declare canPass="$(echo "$filteredUrl" | sed -n -E 's/.*[[:alpha:]].*/true/p')"
-      if [ "$canPass" == "true" ]; then
-        filteredArr+=("$filteredUrl")
-      fi
-    fi
+    done
   done
   echo "${filteredArr[@]}"
 }
@@ -113,7 +111,7 @@ find_file_url() {
   declare -r arch="$(get_arch)"
   declare -r platform="$(get_platform)"
   declare -a assets=($(find_all_asset_names "$install_version"))
-  declare -a usableAssets=( "$(filter_assets "${assets[@]}")" )
+  declare -a usableAssets=($(filter_assets "${assets[@]}"))
 
   if [ "${#usableAssets[@]}" == 0 ]; then
     error_exit "No releases in version $install_version matching $platform $arch-bits"
@@ -133,7 +131,7 @@ download() {
     if [ -z "$download_url" ]; then
       error_exit "Malformed URL"
     fi
-    mkdir "$download_path/bin"
+    mkdir -p "$download_path/bin"
     curl_wrapper -fsS -L -o "${download_path}/bin/jq" "$download_url"
   else
     rm -rf "$download_path"

--- a/bin/download
+++ b/bin/download
@@ -47,9 +47,9 @@ get_assets_url() {
   declare install_version="$1"
 
   if [ -n "${GITHUB_API_TOKEN:+defined}" ]; then
-    declare releases_json="$(curl_wrapper -fsS "$RELEASES_URL" -H "Authorization: token $GITHUB_API_TOKEN")"
+    declare releases_json="$(curl_wrapper -LfsS "$RELEASES_URL" -H "Authorization: token $GITHUB_API_TOKEN")"
   else
-    declare releases_json="$(curl_wrapper -fsS "$RELEASES_URL")"
+    declare releases_json="$(curl_wrapper -LfsS "$RELEASES_URL")"
   fi
 
   declare -a asset_urls
@@ -76,9 +76,9 @@ find_all_asset_names() {
   fi
 
   if [ -n "${GITHUB_API_TOKEN:+defined}" ]; then
-    declare assets_json="$(curl_wrapper -fsS "$assets_url" -H "Authorization: token $GITHUB_API_TOKEN")"
+    declare assets_json="$(curl_wrapper -LfsS "$assets_url" -H "Authorization: token $GITHUB_API_TOKEN")"
   else
-    declare assets_json="$(curl_wrapper -fsS "$assets_url")"
+    declare assets_json="$(curl_wrapper -LfsS "$assets_url")"
   fi
   declare -a output=($(echo "$assets_json" | sed -n -E 's/[[:blank:]]*"browser_download_url":[[:blank:]]{0,2}"([^"]{8,})"/\1/p'))
   echo "${output[@]}"

--- a/bin/install
+++ b/bin/install
@@ -19,8 +19,8 @@ install() {
   declare -r install_path="$3"
 
   if [ "$install_type" == "version" ]; then
-    mkdir "$install_path/bin"
-    mv "$download_path/bin/jq" "$install_path/bin"
+    mkdir -p "$install_path/bin"
+    mv "$download_path/bin/jq" "$install_path/bin/"
     chmod a+x "$install_path/bin/jq"
   else
     cd "$download_path"

--- a/bin/list-all
+++ b/bin/list-all
@@ -22,9 +22,9 @@ sort_versions() {
 
 list_versions() {
   if [ -n "${GITHUB_API_TOKEN:+defined}" ]; then
-    declare releases="$(curl_wrapper -fsS "$RELEASES_URL" -H "Authorization: token $GITHUB_API_TOKEN")"
+    declare releases="$(curl_wrapper -LfsS "$RELEASES_URL" -H "Authorization: token $GITHUB_API_TOKEN")"
   else
-    declare releases="$(curl_wrapper -fsS "$RELEASES_URL")"
+    declare releases="$(curl_wrapper -LfsS "$RELEASES_URL")"
   fi
   echo "$(echo "$releases" | grep -oE "tag_name\": *\".*\"," | sed 's/tag_name\": *\"//;s/\",//')"
 }


### PR DESCRIPTION
- Sync fork with upstream https://github.com/AZMCode/asdf-jq
- Update link-filtering logic to support jq 1.5 - 1.7.1 across linux/macos x86/amd64/arm/arm64.